### PR TITLE
Added border gradient support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,7 +26,7 @@ If applicable, add screenshots to help explain your problem.
 **Smartphone (please complete the following information):**
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
- - Library version [e.g. 0.5.1]
+ - Library version [e.g. 0.6.0]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,44 @@
+name: Build APK
+
+on:
+  push:
+    branches: [ develop ]
+
+jobs:
+  build:
+    name: Setup Environment and build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v2.3.2
+
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2.0.8
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      - name: Generate apk
+        run: ./gradlew sample:assembleDebug --stacktrace
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v3
+        with:
+          name: staging-debug.apk
+          path: sample/build/outputs/apk/debug/sample-debug.apk

--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ files.
 | squircle_shadow_elevation                | dimension | Default of the super view          | Shadow elevation                                                   |
 | squircle_shadow_elevation_color          | color     | #42000000                          | Shadow elevation color                                             |
 | squircle_border_color                    | color     |                                    | Border color                                                       |
+| squircle_border_gradient_drawable        | reference |                                    | Border gradient drawable displayed in view                         |
+| squircle_border_gradient_start_color     | color     |                                    | Border gradient start color                                        |
+| squircle_border_gradient_end_color       | color     |                                    | Border gradient end color                                          |
+| squircle_border_gradient_direction       | enum      | TOP_LEFT_BOTTOM_RIGHT              | Direction of the border gradient (only for the color gradient)     |
 | squircle_border_width                    | dimension | 0                                  | Border width                                                       |
 | squircle_ripple_enabled                  | boolean   | true (false for SquircleImageView) | Ripple enabled or disabled (when a click listener is set)          |
 | squircle_ripple_drawable                 | reference | ?attr/selectableItemBackground     | Drawable used for drawing the ripple                               |
@@ -200,6 +204,12 @@ var backgroundGradientEndColorRes: Int
 var backgroundGradientDirection: GradientDirection
 var borderColor: Int
 var borderColorRes: Int
+var borderGradientDrawable: GradientDrawable?
+var borderGradientStartColor: Int
+var borderGradientStartColorRes: Int
+var borderGradientEndColor: Int
+var borderGradientEndColorRes: Int
+var borderGradientDirection: GradientDirection
 var borderWidth: Float
 var rippleEnabled: Boolean
 
@@ -209,6 +219,8 @@ fun setBackgroundImage(drawable: Drawable?)
 fun setBackgroundImage(resId: Int)
 fun setBackgroundGradientDrawable(resId: Int)
 fun setBackgroundGradientDirection(angle: Int)
+fun setBorderGradientDrawable(resId: Int)
+fun setBorderGradientDirection(angle: Int)
 
 
 fun getCornerSmoothing(): Int
@@ -279,11 +291,11 @@ implementation, which is called `SquircleCornerTreatment`.
 - [ ] Check Java support
 - [ ] Performance testing with lots of bitmaps
 - [ ] Add tests
-- [ ] Code documentation
+- [X] Code documentation
 - [ ] Option to determine text color by background / image
 - [ ] Use precise angle of gradient instead of matching it to a segment
 - [ ] Improve outer shadow boundaries
-- [ ] Jetpack compose support
+- [X] Jetpack compose support
 - [ ] Reduce `invalidate()` calls when changing multiple style properties
 
 ## Contributing
@@ -322,6 +334,12 @@ Check out the [CONTRIBUTING.md](CONTRIBUTING.md) file to know more
 
 ## Changelog
 
+- V0.6.0 (23 may 2022)
+    - Breaking change: 
+      Border gradients have been added, so existing gradient methods are now prefixed with `background_`
+      - Methods renamed: `gradientDrawable` to `backgroundGradientDrawable`, `gradientStartColor` to `backgroundGradientStartColor`, `gradientStartColorRes` to `backgroundGradientStartColorRes`, `gradientEndColor` to `backgroundGradientEndColor`, `gradientEndColorRes` to `backgroundGradientEndColorRes`, `gradientDirection` to `backgroundGradientDirection`
+      - Attributes renamed: `squircle_gradient_drawable` to `squircle_background_gradient_drawable`, `squircle_gradient_start_color` to `squircle_background_gradient_start_color`, `squircle_gradient_end_color` to `squircle_background_gradient_end_color`, `squircle_gradient_direction` to `squircle_background_gradient_direction`
+    - Added border gradient support
 - V0.5.1 (20 may 2022)
     - Android Studio previews would fail due to issues with attributes
 - V0.5.0 (8 april 2022)
@@ -363,7 +381,7 @@ library
 ```
 MIT License
 
-Copyright (c) 2021] Juky
+Copyright (c) 2021 Juky
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Also add the SquircleView dependency to your app build.gradle
 
 ```groovy
 dependencies {
-    implementation "app.juky:squircleview:0.5.1"
+    implementation "app.juky:squircleview:0.6.0"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ This view extends the `AppCompatTextView`, which you can use to have a squircle 
 	android:padding="16dp"
 	android:text="Normal button"
 	android:textColor="#FFFFFF"
-	app:squircle_gradient_end_color="#415FFF"
-	app:squircle_gradient_start_color="#5BA7FF"
+	app:squircle_background_gradient_end_color="#415FFF"
+	app:squircle_background_gradient_start_color="#5BA7FF"
 	app:squircle_shadow_elevation="2dp"/>
 ```
 
@@ -120,8 +120,8 @@ complex layout with texts and icons.
 	android:layout_width="72dp"
 	android:layout_height="72dp"
 	android:padding="16dp"
-	app:squircle_gradient_end_color="#415FFF"
-	app:squircle_gradient_start_color="#5BA7FF"
+	app:squircle_background_gradient_end_color="#415FFF"
+	app:squircle_background_gradient_start_color="#5BA7FF"
 	app:squircle_shadow_elevation="2dp">
 
 	<!-- Embed whatever widget you would like, in this case an icon -->
@@ -162,21 +162,21 @@ Glide.with(this).load(R.drawable.my_image)
 The following attributes can be used in your styles.xml / themes.xml or as attribute of the view in your layout xml
 files.
 
-| Attribute                            | Type      | Default                            | Description                                                |
-|--------------------------------------|-----------|------------------------------------|------------------------------------------------------------|
-| squircle_background_image            | reference |                                    | Background image of view                                   |
-| squircle_background_color            | color     | #000000                            | Background color of view                                   |
-| squircle_gradient_drawable           | reference |                                    | Gradient drawable displayed in view                        |
-| squircle_gradient_start_color        | color     |                                    | Gradient start color                                       |
-| squircle_gradient_end_color          | color     |                                    | Gradient end color                                         |
-| squircle_gradient_direction          | enum      | TOP_LEFT_BOTTOM_RIGHT              | Direction of the gradient (only for the color gradient)    |
-| squircle_shadow_elevation            | dimension | Default of the super view          | Shadow elevation                                           |
-| squircle_shadow_elevation_color      | color     | #42000000                          | Shadow elevation color                                     |
-| squircle_border_color                | color     |                                    | Border color                                               |
-| squircle_border_width                | dimension | 0                                  | Border width                                               |
-| squircle_ripple_enabled              | boolean   | true (false for SquircleImageView) | Ripple enabled or disabled (when a click listener is set)  |
-| squircle_ripple_drawable             | reference | ?attr/selectableItemBackground     | Drawable used for drawing the ripple                       |
-| squircle_corner_smoothing_percentage | integer   | 100%                               | Change the corner smoothing, a Squircle is 100% by default |
+| Attribute                                | Type      | Default                            | Description                                                        |
+|------------------------------------------|-----------|------------------------------------|--------------------------------------------------------------------|
+| squircle_background_image                | reference |                                    | Background image of view                                           |
+| squircle_background_color                | color     | #000000                            | Background color of view                                           |
+| squircle_background_gradient_drawable    | reference |                                    | Background gradient drawable displayed in view                     |
+| squircle_background_gradient_start_color | color     |                                    | Background gradient start color                                    |
+| squircle_background_gradient_end_color   | color     |                                    | Background gradient end color                                      |
+| squircle_background_gradient_direction   | enum      | TOP_LEFT_BOTTOM_RIGHT              | Direction of the background gradient (only for the color gradient) |
+| squircle_shadow_elevation                | dimension | Default of the super view          | Shadow elevation                                                   |
+| squircle_shadow_elevation_color          | color     | #42000000                          | Shadow elevation color                                             |
+| squircle_border_color                    | color     |                                    | Border color                                                       |
+| squircle_border_width                    | dimension | 0                                  | Border width                                                       |
+| squircle_ripple_enabled                  | boolean   | true (false for SquircleImageView) | Ripple enabled or disabled (when a click listener is set)          |
+| squircle_ripple_drawable                 | reference | ?attr/selectableItemBackground     | Drawable used for drawing the ripple                               |
+| squircle_corner_smoothing_percentage     | integer   | 100%                               | Change the corner smoothing, a Squircle is 100% by default         |
 
 ### Methods
 
@@ -192,12 +192,12 @@ var backgroundColorRes: Int
 var shadowElevation: Float
 var shadowElevationColor: Int
 var shadowElevationColorRes: Int
-var gradientDrawable: GradientDrawable?
-var gradientStartColor: Int
-var gradientStartColorRes: Int
-var gradientEndColor: Int
-var gradientEndColorRes: Int
-var gradientDirection: GradientDirection
+var backgroundGradientDrawable: GradientDrawable?
+var backgroundGradientStartColor: Int
+var backgroundGradientStartColorRes: Int
+var backgroundGradientEndColor: Int
+var backgroundGradientEndColorRes: Int
+var backgroundGradientDirection: GradientDirection
 var borderColor: Int
 var borderColorRes: Int
 var borderWidth: Float
@@ -207,8 +207,8 @@ var rippleEnabled: Boolean
 fun setCornerSmoothing(cornerSmoothing: Int)
 fun setBackgroundImage(drawable: Drawable?)
 fun setBackgroundImage(resId: Int)
-fun setGradientDrawable(resId: Int)
-fun setGradientDirection(angle: Int)
+fun setBackgroundGradientDrawable(resId: Int)
+fun setBackgroundGradientDirection(angle: Int)
 
 
 fun getCornerSmoothing(): Int

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -42,7 +42,7 @@ android {
         minSdkVersion 23
         targetSdkVersion 32
         versionCode 1
-        versionName "0.5.1"
+        versionName "0.6.0"
         project.archivesBaseName = "SquircleView"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
     implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'com.google.android.material:material:1.5.0'
+    implementation 'com.google.android.material:material:1.6.0'
     implementation("androidx.compose.material:material:1.1.1")
 
     // Testing

--- a/library/src/main/java/app/juky/squircleview/data/SquircleCore.kt
+++ b/library/src/main/java/app/juky/squircleview/data/SquircleCore.kt
@@ -39,16 +39,16 @@ class SquircleCore(context: Context, attrs: AttributeSet?, view: View) {
 
     var squirclePath = Path()
 
-    var backgroundImage: Bitmap?
-    @ColorInt var backgroundColor: Int
-
     var shadowElevation: Float
     @ColorInt var shadowElevationColor: Int
 
-    var gradientDrawable: GradientDrawable?
-    @ColorInt var gradientStartColor: Int
-    @ColorInt var gradientEndColor: Int
-    var gradientDirection: GradientDirection
+    var backgroundImage: Bitmap?
+    @ColorInt var backgroundColor: Int
+
+    var backgroundGradientDrawable: GradientDrawable?
+    @ColorInt var backgroundGradientStartColor: Int
+    @ColorInt var backgroundGradientEndColor: Int
+    var backgroundGradientDirection: GradientDirection
 
     @ColorInt var borderColor: Int
     var borderWidth: Float
@@ -61,20 +61,22 @@ class SquircleCore(context: Context, attrs: AttributeSet?, view: View) {
 
     init {
         context.obtainStyledAttributes(attrs, R.styleable.SquircleView).apply {
-            backgroundImage = getDrawable(R.styleable.SquircleView_squircle_background_image)?.toBitmap()
-            backgroundColor = getColor(
-                R.styleable.SquircleView_squircle_background_color,
-                ContextCompat.getColor(context, android.R.color.black)
-            )
             shadowElevation = getDimension(R.styleable.SquircleView_squircle_shadow_elevation, view.elevation)
             shadowElevationColor = getColor(
                 R.styleable.SquircleView_squircle_shadow_elevation_color,
                 ContextCompat.getColor(context, R.color.squircle_default_shadow_color)
             )
-            gradientDrawable = getDrawable(R.styleable.SquircleView_squircle_gradient_drawable) as? GradientDrawable
-            gradientStartColor = getColor(R.styleable.SquircleView_squircle_gradient_start_color, DEFAULT_COLOR_VALUE)
-            gradientEndColor = getColor(R.styleable.SquircleView_squircle_gradient_end_color, DEFAULT_COLOR_VALUE)
-            gradientDirection = GradientDirection.values()[getInt(R.styleable.SquircleView_squircle_gradient_direction, GradientDirection.DEFAULT.ordinal)]
+
+            backgroundImage = getDrawable(R.styleable.SquircleView_squircle_background_image)?.toBitmap()
+            backgroundColor = getColor(
+                R.styleable.SquircleView_squircle_background_color,
+                ContextCompat.getColor(context, android.R.color.black)
+            )
+            backgroundGradientDrawable = getDrawable(R.styleable.SquircleView_squircle_background_gradient_drawable) as? GradientDrawable
+            backgroundGradientStartColor = getColor(R.styleable.SquircleView_squircle_background_gradient_start_color, DEFAULT_COLOR_VALUE)
+            backgroundGradientEndColor = getColor(R.styleable.SquircleView_squircle_background_gradient_end_color, DEFAULT_COLOR_VALUE)
+            backgroundGradientDirection = GradientDirection.values()[getInt(R.styleable.SquircleView_squircle_background_gradient_direction, GradientDirection.DEFAULT.ordinal)]
+
             borderColor = getColor(R.styleable.SquircleView_squircle_border_color, DEFAULT_COLOR_VALUE)
             borderWidth = getDimension(R.styleable.SquircleView_squircle_border_width, 0f)
             rippleEnabled = getBoolean(R.styleable.SquircleView_squircle_ripple_enabled, view !is SquircleImageView)

--- a/library/src/main/java/app/juky/squircleview/data/SquircleCore.kt
+++ b/library/src/main/java/app/juky/squircleview/data/SquircleCore.kt
@@ -51,6 +51,12 @@ class SquircleCore(context: Context, attrs: AttributeSet?, view: View) {
     var backgroundGradientDirection: GradientDirection
 
     @ColorInt var borderColor: Int
+
+    var borderGradientDrawable: GradientDrawable?
+    @ColorInt var borderGradientStartColor: Int
+    @ColorInt var borderGradientEndColor: Int
+    var borderGradientDirection: GradientDirection
+
     var borderWidth: Float
 
     var rippleEnabled: Boolean
@@ -78,7 +84,12 @@ class SquircleCore(context: Context, attrs: AttributeSet?, view: View) {
             backgroundGradientDirection = GradientDirection.values()[getInt(R.styleable.SquircleView_squircle_background_gradient_direction, GradientDirection.DEFAULT.ordinal)]
 
             borderColor = getColor(R.styleable.SquircleView_squircle_border_color, DEFAULT_COLOR_VALUE)
+            borderGradientDrawable = getDrawable(R.styleable.SquircleView_squircle_border_gradient_drawable) as? GradientDrawable
+            borderGradientStartColor = getColor(R.styleable.SquircleView_squircle_border_gradient_start_color, DEFAULT_COLOR_VALUE)
+            borderGradientEndColor = getColor(R.styleable.SquircleView_squircle_border_gradient_end_color, DEFAULT_COLOR_VALUE)
+            borderGradientDirection = GradientDirection.values()[getInt(R.styleable.SquircleView_squircle_border_gradient_direction, GradientDirection.DEFAULT.ordinal)]
             borderWidth = getDimension(R.styleable.SquircleView_squircle_border_width, 0f)
+
             rippleEnabled = getBoolean(R.styleable.SquircleView_squircle_ripple_enabled, view !is SquircleImageView)
             rippleDrawable = getDrawable(R.styleable.SquircleView_squircle_ripple_drawable)
             cornerSmoothing = getInteger(R.styleable.SquircleView_squircle_corner_smoothing_percentage, DEFAULT_CORNER_SMOOTHING.toInt())

--- a/library/src/main/java/app/juky/squircleview/data/SquircleStyle.kt
+++ b/library/src/main/java/app/juky/squircleview/data/SquircleStyle.kt
@@ -25,36 +25,6 @@ import app.juky.squircleview.utils.getTransparentRippleDrawable
  */
 class SquircleStyle(val context: Context, val view: View, internal val core: SquircleCore) {
     /**
-     * Set the background image
-     */
-    var backgroundImage: Bitmap?
-        get() = core.backgroundImage
-        set(value) {
-            core.backgroundImage = value
-            view.invalidate()
-        }
-
-    /**
-     * Set the background color by color int
-     */
-    var backgroundColor: Int
-        get() = core.backgroundColor
-        set(@ColorInt color) {
-            core.backgroundColor = color
-            core.shapePaint.color = core.backgroundColor
-            view.invalidate()
-        }
-
-    /**
-     * Set the background color by resource id
-     */
-    var backgroundColorRes: Int
-        get() = core.backgroundColor
-        set(@ColorRes resId) {
-            backgroundColor = ContextCompat.getColor(view.context, resId)
-        }
-
-    /**
      * Set the elevation of the shadow
      */
     var shadowElevation: Float
@@ -90,6 +60,36 @@ class SquircleStyle(val context: Context, val view: View, internal val core: Squ
         set(@ColorRes resId) {
             shadowElevationColor = ContextCompat.getColor(view.context, resId)
         }
+    
+    /**
+     * Set the background image
+     */
+    var backgroundImage: Bitmap?
+        get() = core.backgroundImage
+        set(value) {
+            core.backgroundImage = value
+            view.invalidate()
+        }
+
+    /**
+     * Set the background color by color int
+     */
+    var backgroundColor: Int
+        get() = core.backgroundColor
+        set(@ColorInt color) {
+            core.backgroundColor = color
+            core.shapePaint.color = core.backgroundColor
+            view.invalidate()
+        }
+
+    /**
+     * Set the background color by resource id
+     */
+    var backgroundColorRes: Int
+        get() = core.backgroundColor
+        set(@ColorRes resId) {
+            backgroundColor = ContextCompat.getColor(view.context, resId)
+        }
 
     /**
      * Set a drawable gradient as background. Note: Currently, only Gradient Drawables which have
@@ -105,60 +105,60 @@ class SquircleStyle(val context: Context, val view: View, internal val core: Squ
      * </shape>
      * ```
      */
-    var gradientDrawable: GradientDrawable?
-        get() = core.gradientDrawable
+    var backgroundGradientDrawable: GradientDrawable?
+        get() = core.backgroundGradientDrawable
         set(drawable) {
-            core.gradientDrawable = drawable
+            core.backgroundGradientDrawable = drawable
             view.invalidate()
         }
 
     /**
-     * Set the gradient start color by color int
+     * Set the background gradient start color by color int
      */
-    var gradientStartColor: Int
-        get() = core.gradientStartColor
+    var backgroundGradientStartColor: Int
+        get() = core.backgroundGradientStartColor
         set(@ColorInt color) {
-            core.gradientStartColor = color
+            core.backgroundGradientStartColor = color
             view.invalidate()
         }
 
     /**
-     * Set the gradient start color by resource ID. Note: this CANNOT be an android.R.color.* value, because
+     * Set the background gradient start color by resource ID. Note: this CANNOT be an android.R.color.* value, because
      * it won't work with a LinearGradient.
      */
-    var gradientStartColorRes: Int
-        get() = core.gradientStartColor
+    var backgroundGradientStartColorRes: Int
+        get() = core.backgroundGradientStartColor
         set(@ColorRes resId) {
-            gradientStartColor = ContextCompat.getColor(view.context, resId)
+            backgroundGradientStartColor = ContextCompat.getColor(view.context, resId)
         }
 
     /**
-     * Set the gradient end color by color int
+     * Set the background gradient end color by color int
      */
-    var gradientEndColor: Int
-        get() = core.gradientEndColor
+    var backgroundGradientEndColor: Int
+        get() = core.backgroundGradientEndColor
         set(@ColorInt color) {
-            core.gradientEndColor = color
+            core.backgroundGradientEndColor = color
             view.invalidate()
         }
 
     /**
-     * Set the gradient end color by resource ID. Note: this CANNOT be an android.R.color.* value, because
+     * Set the background gradient end color by resource ID. Note: this CANNOT be an android.R.color.* value, because
      * it won't work with a LinearGradient.
      */
-    var gradientEndColorRes: Int
-        get() = core.gradientEndColor
+    var backgroundGradientEndColorRes: Int
+        get() = core.backgroundGradientEndColor
         set(@ColorRes resId) {
-            gradientEndColor = ContextCompat.getColor(view.context, resId)
+            backgroundGradientEndColor = ContextCompat.getColor(view.context, resId)
         }
 
     /**
-     * Set the gradient direction using a GradientDirection
+     * Set the background gradient direction using a GradientDirection
      */
-    var gradientDirection: GradientDirection
-        get() = core.gradientDirection
+    var backgroundGradientDirection: GradientDirection
+        get() = core.backgroundGradientDirection
         set(direction) {
-            core.gradientDirection = direction
+            core.backgroundGradientDirection = direction
             SquircleGradient.onViewSizeChanged(view.width, view.height, view, core)
         }
 
@@ -287,8 +287,21 @@ class SquircleStyle(val context: Context, val view: View, internal val core: Squ
      * ```
      * @param resId Int Resource id of gradient
      */
-    fun setGradientDrawable(@DrawableRes resId: Int) {
-        core.gradientDrawable = ContextCompat.getDrawable(context, resId) as? GradientDrawable
+    fun setBackgroundGradientDrawable(@DrawableRes resId: Int) {
+        core.backgroundGradientDrawable = ContextCompat.getDrawable(context, resId) as? GradientDrawable
+        view.invalidate()
+    }
+
+    /**
+     * Set the gradient direction using an angle from 0 to 360
+     *
+     * @param angle Int Angle from 0 to 360 degrees
+     */
+    fun setBackgroundGradientDirection(angle: Int) {
+        core.backgroundGradientDirection = GradientDirection.getByAngle(angle)
+        SquircleGradient.onViewSizeChanged(view.width, view.height, view, core)
+    }
+
         view.invalidate()
     }
 

--- a/library/src/main/java/app/juky/squircleview/data/SquircleStyle.kt
+++ b/library/src/main/java/app/juky/squircleview/data/SquircleStyle.kt
@@ -61,6 +61,7 @@ class SquircleStyle(val context: Context, val view: View, internal val core: Squ
             shadowElevationColor = ContextCompat.getColor(view.context, resId)
         }
     
+
     /**
      * Set the background image
      */
@@ -186,6 +187,78 @@ class SquircleStyle(val context: Context, val view: View, internal val core: Squ
             borderColor = ContextCompat.getColor(view.context, resId)
         }
 
+
+    /**
+     * Set a drawable gradient as border background. Note: Currently, only Gradient Drawables which have
+     * a shape around it are supported, though you could just use a shape without specifying anything.
+     *
+     * ```
+     * <?xml version="1.0" encoding="utf-8"?>
+     * <shape xmlns:android="http://schemas.android.com/apk/res/android">
+     *     <gradient
+     *         android:endColor="#EC5396"
+     *         android:startColor="#FFCB71"
+     *         android:type="linear" />
+     * </shape>
+     * ```
+     */
+    var borderGradientDrawable: GradientDrawable?
+        get() = core.borderGradientDrawable
+        set(drawable) {
+            core.borderGradientDrawable = drawable
+            view.invalidate()
+        }
+
+    /**
+     * Set the border gradient start color by color int
+     */
+    var borderGradientStartColor: Int
+        get() = core.borderGradientStartColor
+        set(@ColorInt color) {
+            core.borderGradientStartColor = color
+            view.invalidate()
+        }
+
+    /**
+     * Set the border gradient start color by resource ID. Note: this CANNOT be an android.R.color.* value, because
+     * it won't work with a LinearGradient.
+     */
+    var borderGradientStartColorRes: Int
+        get() = core.borderGradientStartColor
+        set(@ColorRes resId) {
+            borderGradientStartColor = ContextCompat.getColor(view.context, resId)
+        }
+
+    /**
+     * Set the border gradient end color by color int
+     */
+    var borderGradientEndColor: Int
+        get() = core.borderGradientEndColor
+        set(@ColorInt color) {
+            core.borderGradientEndColor = color
+            view.invalidate()
+        }
+
+    /**
+     * Set the border gradient end color by resource ID. Note: this CANNOT be an android.R.color.* value, because
+     * it won't work with a LinearGradient.
+     */
+    var borderGradientEndColorRes: Int
+        get() = core.borderGradientEndColor
+        set(@ColorRes resId) {
+            borderGradientEndColor = ContextCompat.getColor(view.context, resId)
+        }
+
+    /**
+     * Set the border gradient direction using a GradientDirection
+     */
+    var borderGradientDirection: GradientDirection
+        get() = core.borderGradientDirection
+        set(direction) {
+            core.borderGradientDirection = direction
+            SquircleGradient.onViewSizeChanged(view.width, view.height, view, core)
+        }
+
     /**
      * Set the width of the border
      */
@@ -302,6 +375,23 @@ class SquircleStyle(val context: Context, val view: View, internal val core: Squ
         SquircleGradient.onViewSizeChanged(view.width, view.height, view, core)
     }
 
+    /**
+     * Set the gradient as border using a gradient resource id. Note: Currently, only Gradient Drawables which have
+     * a shape around it are supported, though you could just use a shape without specifying anything.
+     *
+     * ```
+     * <?xml version="1.0" encoding="utf-8"?>
+     * <shape xmlns:android="http://schemas.android.com/apk/res/android">
+     *     <gradient
+     *         android:endColor="#EC5396"
+     *         android:startColor="#FFCB71"
+     *         android:type="linear" />
+     * </shape>
+     * ```
+     * @param resId Int Resource id of gradient
+     */
+    fun setBorderGradientDrawable(@DrawableRes resId: Int) {
+        core.borderGradientDrawable = ContextCompat.getDrawable(context, resId) as? GradientDrawable
         view.invalidate()
     }
 
@@ -310,8 +400,8 @@ class SquircleStyle(val context: Context, val view: View, internal val core: Squ
      *
      * @param angle Int Angle from 0 to 360 degrees
      */
-    fun setGradientDirection(angle: Int) {
-        core.gradientDirection = GradientDirection.getByAngle(angle)
+    fun setBorderGradientDirection(angle: Int) {
+        core.borderGradientDirection = GradientDirection.getByAngle(angle)
         SquircleGradient.onViewSizeChanged(view.width, view.height, view, core)
     }
 

--- a/library/src/main/java/app/juky/squircleview/utils/SquircleGradient.kt
+++ b/library/src/main/java/app/juky/squircleview/utils/SquircleGradient.kt
@@ -5,6 +5,7 @@ import android.graphics.Shader
 import android.graphics.drawable.GradientDrawable
 import android.os.Build
 import android.view.View
+import androidx.annotation.ColorInt
 import androidx.core.content.ContextCompat
 import app.juky.squircleview.data.GradientDirection
 import app.juky.squircleview.data.SquircleCore
@@ -15,45 +16,58 @@ internal object SquircleGradient {
     // Draw in onSizeChanged to reduce recalculations on every draw
     fun onViewSizeChanged(newWidth: Int, newHeight: Int, view: View, core: SquircleCore) {
         if (newWidth > 0 && newHeight > 0) {
-            core.shapePaint.shader = getGradient(view = view, core = core)
+            core.shapePaint.shader = getGradient(
+                view = view,
+                direction = core.backgroundGradientDirection,
+                startColor = core.backgroundGradientStartColor,
+                endColor = core.backgroundGradientEndColor,
+                drawable = core.backgroundGradientDrawable
+            )
             view.invalidate()
         }
     }
 
-    private fun getGradient(view: View, core: SquircleCore): LinearGradient? {
-        if (core.gradientStartColor == DEFAULT_COLOR_VALUE && core.gradientEndColor == DEFAULT_COLOR_VALUE && core.gradientDrawable == null) {
+    private fun getGradient(
+        view: View,
+        direction: GradientDirection,
+        @ColorInt startColor: Int,
+        @ColorInt endColor: Int,
+        drawable: GradientDrawable?
+    ): LinearGradient? {
+        if (startColor == DEFAULT_COLOR_VALUE && endColor == DEFAULT_COLOR_VALUE && drawable == null) {
             // No colors nor drawable known, no gradient available
             return null
         }
 
-        core.gradientDrawable?.let { gradientDrawable ->
-            return getGradientByDrawable(view = view, core = core, gradientDrawable = gradientDrawable)
+        drawable?.let { gradientDrawable ->
+            return getGradientByDrawable(view = view, direction = direction, gradientDrawable = gradientDrawable)
         } ?: run {
             // Using manual colors instead of gradient drawable
-            return getGradientByColor(view = view, core = core)
+            return getGradientByColor(view = view, direction = direction, startColor = startColor, endColor = endColor)
         }
     }
 
-    private fun getGradientByColor(view: View, core: SquircleCore): LinearGradient {
-        val direction = GradientDirection.getCoordinatesByDirection(view = view, direction = core.gradientDirection)
+    private fun getGradientByColor(view: View, direction: GradientDirection, @ColorInt startColor: Int, @ColorInt endColor: Int): LinearGradient {
+        val gradientDirection = GradientDirection.getCoordinatesByDirection(view = view, direction = direction)
 
         return LinearGradient(
-            direction.startX.toFloat(),
-            direction.startY.toFloat(),
-            direction.endX.toFloat(),
-            direction.endY.toFloat(),
-            core.gradientStartColor,
-            core.gradientEndColor,
+            gradientDirection.startX.toFloat(),
+            gradientDirection.startY.toFloat(),
+            gradientDirection.endX.toFloat(),
+            gradientDirection.endY.toFloat(),
+            startColor,
+            endColor,
             Shader.TileMode.REPEAT
         )
     }
 
-    private fun getGradientByDrawable(view: View, core: SquircleCore, gradientDrawable: GradientDrawable): LinearGradient {
+    private fun getGradientByDrawable(view: View, direction: GradientDirection, gradientDrawable: GradientDrawable): LinearGradient {
         fun transparentColor() = ContextCompat.getColor(view.context, android.R.color.transparent)
-        val coordinates: GradientDirection.GradientCoordinates = if (core.gradientDirection == GradientDirection.DEFAULT) {
+
+        val coordinates: GradientDirection.GradientCoordinates = if (direction == GradientDirection.DEFAULT) {
             GradientDirection.getCoordinates(view = view, orientation = gradientDrawable.orientation)
         } else {
-            GradientDirection.getCoordinatesByDirection(view = view, direction = core.gradientDirection)
+            GradientDirection.getCoordinatesByDirection(view = view, direction = direction)
         }
 
         // Gradient drawable does not contain colors in Android < N

--- a/library/src/main/java/app/juky/squircleview/utils/SquircleGradient.kt
+++ b/library/src/main/java/app/juky/squircleview/utils/SquircleGradient.kt
@@ -23,6 +23,14 @@ internal object SquircleGradient {
                 endColor = core.backgroundGradientEndColor,
                 drawable = core.backgroundGradientDrawable
             )
+            core.borderPaint.shader = getGradient(
+                view = view,
+                direction = core.borderGradientDirection,
+                startColor = core.borderGradientStartColor,
+                endColor = core.borderGradientEndColor,
+                drawable = core.borderGradientDrawable
+            )
+
             view.invalidate()
         }
     }

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -36,6 +36,27 @@
     <!-- Border color -->
     <attr name="squircle_border_color" format="color" />
 
+    <!-- Border gradient drawable -->
+    <attr name="squircle_border_gradient_drawable" format="reference" />
+
+    <!-- Border gradient start color -->
+    <attr name="squircle_border_gradient_start_color" format="color" />
+
+    <!-- Border gradient end color -->
+    <attr name="squircle_border_gradient_end_color" format="color" />
+
+    <!-- Direction of the border gradient (only for the color gradient) -->
+    <attr name="squircle_border_gradient_direction">
+        <enum name="top_to_bottom" value="0" />
+        <enum name="top_right_to_bottom_left" value="1" />
+        <enum name="right_to_left" value="2" />
+        <enum name="bottom_right_to_top_left" value="3" />
+        <enum name="bottom_to_top" value="4" />
+        <enum name="bottom_left_to_top_right" value="5" />
+        <enum name="left_to_right" value="6" />
+        <enum name="top_left_to_bottom_right" value="7" />
+    </attr>
+
     <!-- Border width -->
     <attr name="squircle_border_width" format="dimension" />
 
@@ -59,6 +80,10 @@
         <attr name="squircle_shadow_elevation" />
         <attr name="squircle_shadow_elevation_color" />
         <attr name="squircle_border_color" />
+        <attr name="squircle_border_gradient_drawable" />
+        <attr name="squircle_border_gradient_start_color" />
+        <attr name="squircle_border_gradient_end_color" />
+        <attr name="squircle_border_gradient_direction" />
         <attr name="squircle_border_width" />
         <attr name="squircle_ripple_enabled" />
         <attr name="squircle_ripple_drawable" />
@@ -75,6 +100,10 @@
         <attr name="squircle_shadow_elevation" />
         <attr name="squircle_shadow_elevation_color" />
         <attr name="squircle_border_color" />
+        <attr name="squircle_border_gradient_drawable" />
+        <attr name="squircle_border_gradient_start_color" />
+        <attr name="squircle_border_gradient_end_color" />
+        <attr name="squircle_border_gradient_direction" />
         <attr name="squircle_border_width" />
         <attr name="squircle_ripple_enabled" />
         <attr name="squircle_ripple_drawable" />
@@ -91,6 +120,10 @@
         <attr name="squircle_shadow_elevation" />
         <attr name="squircle_shadow_elevation_color" />
         <attr name="squircle_border_color" />
+        <attr name="squircle_border_gradient_drawable" />
+        <attr name="squircle_border_gradient_start_color" />
+        <attr name="squircle_border_gradient_end_color" />
+        <attr name="squircle_border_gradient_direction" />
         <attr name="squircle_border_width" />
         <attr name="squircle_ripple_enabled" />
         <attr name="squircle_ripple_drawable" />
@@ -107,6 +140,10 @@
         <attr name="squircle_shadow_elevation" />
         <attr name="squircle_shadow_elevation_color" />
         <attr name="squircle_border_color" />
+        <attr name="squircle_border_gradient_drawable" />
+        <attr name="squircle_border_gradient_start_color" />
+        <attr name="squircle_border_gradient_end_color" />
+        <attr name="squircle_border_gradient_direction" />
         <attr name="squircle_border_width" />
         <attr name="squircle_ripple_enabled" />
         <attr name="squircle_ripple_drawable" />

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -7,16 +7,16 @@
     <attr name="squircle_background_color" format="color" />
 
     <!-- Gradient drawable displayed in view -->
-    <attr name="squircle_gradient_drawable" format="reference" />
+    <attr name="squircle_background_gradient_drawable" format="reference" />
 
     <!-- Gradient start color -->
-    <attr name="squircle_gradient_start_color" format="color" />
+    <attr name="squircle_background_gradient_start_color" format="color" />
 
     <!-- Gradient end color -->
-    <attr name="squircle_gradient_end_color" format="color" />
+    <attr name="squircle_background_gradient_end_color" format="color" />
 
     <!-- Direction of the gradient (only for the color gradient) -->
-    <attr name="squircle_gradient_direction">
+    <attr name="squircle_background_gradient_direction">
         <enum name="top_to_bottom" value="0" />
         <enum name="top_right_to_bottom_left" value="1" />
         <enum name="right_to_left" value="2" />
@@ -52,10 +52,10 @@
     <declare-styleable name="SquircleView">
         <attr name="squircle_background_image" />
         <attr name="squircle_background_color" />
-        <attr name="squircle_gradient_drawable" />
-        <attr name="squircle_gradient_start_color" />
-        <attr name="squircle_gradient_end_color" />
-        <attr name="squircle_gradient_direction" />
+        <attr name="squircle_background_gradient_drawable" />
+        <attr name="squircle_background_gradient_start_color" />
+        <attr name="squircle_background_gradient_end_color" />
+        <attr name="squircle_background_gradient_direction" />
         <attr name="squircle_shadow_elevation" />
         <attr name="squircle_shadow_elevation_color" />
         <attr name="squircle_border_color" />
@@ -68,10 +68,10 @@
     <declare-styleable name="SquircleButton">
         <attr name="squircle_background_image" />
         <attr name="squircle_background_color" />
-        <attr name="squircle_gradient_drawable" />
-        <attr name="squircle_gradient_start_color" />
-        <attr name="squircle_gradient_end_color" />
-        <attr name="squircle_gradient_direction" />
+        <attr name="squircle_background_gradient_drawable" />
+        <attr name="squircle_background_gradient_start_color" />
+        <attr name="squircle_background_gradient_end_color" />
+        <attr name="squircle_background_gradient_direction" />
         <attr name="squircle_shadow_elevation" />
         <attr name="squircle_shadow_elevation_color" />
         <attr name="squircle_border_color" />
@@ -84,10 +84,10 @@
     <declare-styleable name="SquircleConstraintLayout">
         <attr name="squircle_background_image" />
         <attr name="squircle_background_color" />
-        <attr name="squircle_gradient_drawable" />
-        <attr name="squircle_gradient_start_color" />
-        <attr name="squircle_gradient_end_color" />
-        <attr name="squircle_gradient_direction" />
+        <attr name="squircle_background_gradient_drawable" />
+        <attr name="squircle_background_gradient_start_color" />
+        <attr name="squircle_background_gradient_end_color" />
+        <attr name="squircle_background_gradient_direction" />
         <attr name="squircle_shadow_elevation" />
         <attr name="squircle_shadow_elevation_color" />
         <attr name="squircle_border_color" />
@@ -100,10 +100,10 @@
     <declare-styleable name="SquircleImageView">
         <attr name="squircle_background_image" />
         <attr name="squircle_background_color" />
-        <attr name="squircle_gradient_drawable" />
-        <attr name="squircle_gradient_start_color" />
-        <attr name="squircle_gradient_end_color" />
-        <attr name="squircle_gradient_direction" />
+        <attr name="squircle_background_gradient_drawable" />
+        <attr name="squircle_background_gradient_start_color" />
+        <attr name="squircle_background_gradient_end_color" />
+        <attr name="squircle_background_gradient_direction" />
         <attr name="squircle_shadow_elevation" />
         <attr name="squircle_shadow_elevation_color" />
         <attr name="squircle_border_color" />

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     implementation project(':library')
 
     // Test the library using the Maven central / local dependency
-    //implementation 'app.juky:squircleview:0.5.1'
+    //implementation 'app.juky:squircleview:0.6.0'
 
     // Image loading
     implementation 'com.github.bumptech.glide:glide:4.13.2'

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation 'com.google.android.material:material:1.5.0'
+    implementation 'com.google.android.material:material:1.6.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
     implementation("androidx.compose.material:material:1.1.1")
 
@@ -65,8 +65,8 @@ dependencies {
     //implementation 'app.juky:squircleview:0.5.1'
 
     // Image loading
-    implementation 'com.github.bumptech.glide:glide:4.13.1'
-    kapt 'com.github.bumptech.glide:compiler:4.13.1'
+    implementation 'com.github.bumptech.glide:glide:4.13.2'
+    kapt 'com.github.bumptech.glide:compiler:4.13.2'
 
     // Testing
     testImplementation 'junit:junit:4.13.2'

--- a/sample/src/main/java/app/juky/squircleview/sample/MainActivity.kt
+++ b/sample/src/main/java/app/juky/squircleview/sample/MainActivity.kt
@@ -127,12 +127,12 @@ class MainActivity : AppCompatActivity() {
         // binding.normalButton.style.shadowElevation = 8f
         // binding.normalButton.style.shadowElevationColor = Color.GREEN
         // binding.normalButton.style.shadowElevationColorRes = R.color.teal_200
-        // binding.normalButton.style.gradientDrawable = ContextCompat.getDrawable(this, R.drawable.gradient_second) as? GradientDrawable
-        // binding.normalButton.style.gradientStartColor = Color.BLUE
-        // binding.normalButton.style.gradientStartColorRes = R.color.purple_500
-        // binding.normalButton.style.gradientEndColor = Color.YELLOW
-        // binding.normalButton.style.gradientEndColorRes = R.color.teal_700
-        // binding.normalButton.style.gradientDirection = GradientDirection.BOTTOM_TOP
+        // binding.normalButton.style.backgroundGradientDrawable = ContextCompat.getDrawable(this, R.drawable.gradient_second) as? GradientDrawable
+        // binding.normalButton.style.backgroundGradientStartColor = Color.BLUE
+        // binding.normalButton.style.backgroundGradientStartColorRes = R.color.purple_500
+        // binding.normalButton.style.backgroundGradientEndColor = Color.YELLOW
+        // binding.normalButton.style.backgroundGradientEndColorRes = R.color.teal_700
+        // binding.normalButton.style.backgroundGradientDirection = GradientDirection.BOTTOM_TOP
         // binding.normalButton.style.borderColor = Color.CYAN
         // binding.normalButton.style.borderColorRes = R.color.purple_500
         // binding.normalButton.style.borderWidth = 20f
@@ -141,8 +141,8 @@ class MainActivity : AppCompatActivity() {
 
         // binding.normalButton.style.setBackgroundImage(ContextCompat.getDrawable(this, R.drawable.second_image))
         // binding.normalButton.style.setBackgroundImage(R.drawable.third_image)
-        // binding.normalButton.style.setGradientDrawable(R.drawable.gradient_second)
-        // binding.normalButton.style.setGradientDirection(200)
+        // binding.normalButton.style.setBackgroundGradientDrawable(R.drawable.gradient_second)
+        // binding.normalButton.style.setBackgroundGradientDirection(200)
     }
 
     private fun loadImageDrawable() {

--- a/sample/src/main/java/app/juky/squircleview/sample/MainActivity.kt
+++ b/sample/src/main/java/app/juky/squircleview/sample/MainActivity.kt
@@ -135,6 +135,12 @@ class MainActivity : AppCompatActivity() {
         // binding.normalButton.style.backgroundGradientDirection = GradientDirection.BOTTOM_TOP
         // binding.normalButton.style.borderColor = Color.CYAN
         // binding.normalButton.style.borderColorRes = R.color.purple_500
+        // binding.normalButton.style.borderGradientDrawable = ContextCompat.getDrawable(this, R.drawable.gradient_second) as? GradientDrawable
+        // binding.normalButton.style.borderGradientStartColor = Color.BLUE
+        // binding.normalButton.style.borderGradientStartColorRes = R.color.purple_500
+        // binding.normalButton.style.borderGradientEndColor = Color.YELLOW
+        // binding.normalButton.style.borderGradientEndColorRes = R.color.teal_700
+        // binding.normalButton.style.borderGradientDirection = GradientDirection.BOTTOM_TOP
         // binding.normalButton.style.borderWidth = 20f
         // binding.normalButton.style.rippleEnabled = false
         // binding.normalButton.style.rippleDrawable = ContextCompat.getDrawable(this, R.drawable.ripple)
@@ -143,6 +149,8 @@ class MainActivity : AppCompatActivity() {
         // binding.normalButton.style.setBackgroundImage(R.drawable.third_image)
         // binding.normalButton.style.setBackgroundGradientDrawable(R.drawable.gradient_second)
         // binding.normalButton.style.setBackgroundGradientDirection(200)
+        // binding.normalButton.style.setBorderGradientDrawable(R.drawable.gradient_second)
+        // binding.normalButton.style.setBorderGradientDirection(200)
     }
 
     private fun loadImageDrawable() {

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -72,9 +72,9 @@
                 android:layout_height="72dp"
                 android:layout_margin="8dp"
                 android:padding="16dp"
+                app:squircle_background_gradient_end_color="#415FFF"
+                app:squircle_background_gradient_start_color="#5BA7FF"
                 app:squircle_corner_smoothing_percentage="40"
-                app:squircle_gradient_end_color="#415FFF"
-                app:squircle_gradient_start_color="#5BA7FF"
                 app:squircle_ripple_enabled="false"
                 app:squircle_shadow_elevation="2dp">
 
@@ -96,7 +96,7 @@
                 android:layout_height="72dp"
                 android:layout_margin="8dp"
                 android:padding="16dp"
-                app:squircle_gradient_drawable="@drawable/gradient"
+                app:squircle_background_gradient_drawable="@drawable/gradient"
                 app:squircle_shadow_elevation="2dp">
 
                 <androidx.appcompat.widget.AppCompatImageView
@@ -117,10 +117,10 @@
                 android:layout_height="72dp"
                 android:layout_margin="8dp"
                 android:padding="16dp"
+                app:squircle_background_gradient_end_color="#C739EF"
+                app:squircle_background_gradient_start_color="#E0ED24"
                 app:squircle_border_color="#AE553A"
                 app:squircle_border_width="8dp"
-                app:squircle_gradient_end_color="#C739EF"
-                app:squircle_gradient_start_color="#E0ED24"
                 app:squircle_shadow_elevation="2dp">
 
                 <androidx.appcompat.widget.AppCompatImageView
@@ -141,9 +141,9 @@
                 android:layout_height="72dp"
                 android:layout_margin="8dp"
                 android:padding="16dp"
-                app:squircle_gradient_direction="bottom_left_to_top_right"
-                app:squircle_gradient_end_color="#0EBA11"
-                app:squircle_gradient_start_color="#FFBB0D"
+                app:squircle_background_gradient_direction="bottom_left_to_top_right"
+                app:squircle_background_gradient_end_color="#0EBA11"
+                app:squircle_background_gradient_start_color="#FFBB0D"
                 app:squircle_shadow_elevation="0dp">
 
                 <androidx.appcompat.widget.AppCompatImageView
@@ -172,8 +172,8 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/squircleRowLayout"
             app:squircle_background_color="@color/purple_200"
-            app:squircle_gradient_end_color="#415FFF"
-            app:squircle_gradient_start_color="#5BA7FF"
+            app:squircle_background_gradient_end_color="#415FFF"
+            app:squircle_background_gradient_start_color="#5BA7FF"
             app:squircle_shadow_elevation="2dp" />
 
         <app.juky.squircleview.views.SquircleButton
@@ -213,10 +213,10 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent"
                     app:squircle_background_color="@color/purple_200"
+                    app:squircle_background_gradient_drawable="@drawable/gradient"
                     app:squircle_background_image="@drawable/first_image"
                     app:squircle_border_color="@color/black"
                     app:squircle_border_width="4dp"
-                    app:squircle_gradient_drawable="@drawable/gradient" />
 
                 <app.juky.squircleview.views.SquircleButton
                     android:id="@+id/normalButtonWithImage"
@@ -227,11 +227,11 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/imageButton"
                     app:squircle_background_color="@color/purple_200"
+                    app:squircle_background_gradient_end_color="#FF00FF"
+                    app:squircle_background_gradient_start_color="#C6A116"
                     app:squircle_background_image="@drawable/third_image"
                     app:squircle_border_color="@color/white"
                     app:squircle_border_width="4dp"
-                    app:squircle_gradient_end_color="#FF00FF"
-                    app:squircle_gradient_start_color="#C6A116" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -245,11 +245,11 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/normalButtonWithImage"
+                app:squircle_background_gradient_direction="right_to_left"
+                app:squircle_background_gradient_end_color="#FF00FF"
+                app:squircle_background_gradient_start_color="#C6A116"
                 app:squircle_border_color="@color/white"
                 app:squircle_border_width="4dp"
-                app:squircle_gradient_direction="right_to_left"
-                app:squircle_gradient_end_color="#FF00FF"
-                app:squircle_gradient_start_color="#C6A116" />
 
         </androidx.appcompat.widget.LinearLayoutCompat>
 

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -96,6 +96,9 @@
                 android:layout_height="72dp"
                 android:layout_margin="8dp"
                 android:padding="16dp"
+                app:squircle_border_width="10dp"
+                app:squircle_border_gradient_direction="top_left_to_bottom_right"
+                app:squircle_border_gradient_drawable="@drawable/gradient_second"
                 app:squircle_background_gradient_drawable="@drawable/gradient"
                 app:squircle_shadow_elevation="2dp">
 
@@ -119,8 +122,10 @@
                 android:padding="16dp"
                 app:squircle_background_gradient_end_color="#C739EF"
                 app:squircle_background_gradient_start_color="#E0ED24"
+                app:squircle_border_gradient_start_color="@color/teal_200"
+                app:squircle_border_gradient_end_color="@color/purple_700"
                 app:squircle_border_color="#AE553A"
-                app:squircle_border_width="8dp"
+                app:squircle_border_width="16dp"
                 app:squircle_shadow_elevation="2dp">
 
                 <androidx.appcompat.widget.AppCompatImageView
@@ -216,7 +221,7 @@
                     app:squircle_background_gradient_drawable="@drawable/gradient"
                     app:squircle_background_image="@drawable/first_image"
                     app:squircle_border_color="@color/black"
-                    app:squircle_border_width="4dp"
+                    app:squircle_border_width="4dp" />
 
                 <app.juky.squircleview.views.SquircleButton
                     android:id="@+id/normalButtonWithImage"
@@ -231,7 +236,7 @@
                     app:squircle_background_gradient_start_color="#C6A116"
                     app:squircle_background_image="@drawable/third_image"
                     app:squircle_border_color="@color/white"
-                    app:squircle_border_width="4dp"
+                    app:squircle_border_width="4dp" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -249,7 +254,7 @@
                 app:squircle_background_gradient_end_color="#FF00FF"
                 app:squircle_background_gradient_start_color="#C6A116"
                 app:squircle_border_color="@color/white"
-                app:squircle_border_width="4dp"
+                app:squircle_border_width="4dp" />
 
         </androidx.appcompat.widget.LinearLayoutCompat>
 


### PR DESCRIPTION
Due to the introduction of a border gradient, the generic gradient attributes and variables need to be prefixed with background_. This is a breaking change, but unfortunately, this is the way.